### PR TITLE
feat: add .exists() to check if a command exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,20 @@ commands.list.forEach(function (command) {
 });
 ```
 
-`.hasFlag` is used to check if the command has the flag:
+`.exists()` is used to check if the command exists:
+
+```javascript
+commands.exists('set') // true
+commands.exists('other-command') // false
+```
+
+`.hasFlag()` is used to check if the command has the flag:
 
 ```javascript
 commands.hasFlag('set', 'readonly') // false
 ```
 
-`.getKeyIndexes` is used to get the indexes of keys in the command arguments:
+`.getKeyIndexes()` is used to get the indexes of keys in the command arguments:
 
 ```javascript
 commands.getKeyIndexes('set', ['key', 'value']) // [0]

--- a/index.js
+++ b/index.js
@@ -13,6 +13,17 @@ var commands = require('./commands');
 exports.list = Object.keys(commands);
 
 /**
+ * Check if the command exists
+ *
+ * @param {string} commandName - the command name
+ * @return {boolean} result
+ * @public
+ */
+exports.exists = function (commandName) {
+  return Boolean(commands[commandName]);
+};
+
+/**
  * Check if the command has the flag
  *
  * Some of possible flags: readonly, noscript, loading

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,23 @@ describe('redis-commands', function () {
     });
   });
 
-  describe('.hasFlag', function () {
+  describe('.exists()', function () {
+    it('should return true for existing commands', function () {
+      expect(commands.exists('set')).to.eql(true);
+      expect(commands.exists('get')).to.eql(true);
+      expect(commands.exists('cluster')).to.eql(true);
+      expect(commands.exists('quit')).to.eql(true);
+      expect(commands.exists('config')).to.eql(true);
+    });
+
+    it('should return false for non-existing commands', function () {
+      expect(commands.exists('SET')).to.eql(false);
+      expect(commands.exists('set get')).to.eql(false);
+      expect(commands.exists('other-command')).to.eql(false);
+    });
+  });
+
+  describe('.hasFlag()', function () {
     it('should return true if the command has the flag', function () {
       expect(commands.hasFlag('set', 'write')).to.eql(true);
       expect(commands.hasFlag('set', 'denyoom')).to.eql(true);
@@ -41,7 +57,7 @@ describe('redis-commands', function () {
     });
   });
 
-  describe('.getKeyIndexes', function () {
+  describe('.getKeyIndexes()', function () {
     var index = commands.getKeyIndexes;
 
     it('should return key indexes', function () {


### PR DESCRIPTION
Although currently is able to check if a command exists by iterating `commands.list`, a `exists()` method would be more convenient and efficient.  