### PR TITLE
perf: improve performance of .hasFlag()

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,13 @@ var commands = require('./commands');
  */
 exports.list = Object.keys(commands);
 
+var flags = {};
+exports.list.forEach(function (commandName) {
+  flags[commandName] = commands[commandName].flags.reduce(function (flags, flag) {
+    flags[flag] = true;
+    return flags;
+  }, {});
+});
 /**
  * Check if the command has the flag
  *
@@ -22,20 +29,11 @@ exports.list = Object.keys(commands);
  * @public
  */
 exports.hasFlag = function (commandName, flag) {
-  var command = commands[commandName];
-  if (!command) {
+  if (!flags[commandName]) {
     throw new Error('Unknown command ' + commandName);
   }
 
-  var flags = command.flags;
-
-  for (var i = 0; i < flags.length; i++) {
-    if (flags[i] === flag) {
-      return true;
-    }
-  }
-
-  return false;
+  return Boolean(flags[commandName][flag]);
 };
 
 /**


### PR DESCRIPTION
Use an object to store the flags so that we don't need to iterate the flags array every time.