### PR TITLE
Fix for Bug: xread in cluster mode calculates slots on wrong arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,19 @@ exports.getKeyIndexes = function (commandName, args, options) {
         keys.push(2)
       }
       break
+    case 'xread':
+      for (i = 0; i < args.length - 1; i++) {
+        if (args[i].toUpperCase() === 'STREAMS') {
+          var streamStart = i + 1;
+          var streamsAndIdsCount = (args.length-streamStart);
+          if(streamsAndIdsCount%2!=0) throw new Error("ID count doesnt match to Stream count")
+          for (var j=streamStart; j<streamStart+(streamsAndIdsCount/2) ;j++) {
+            keys.push(j)
+          }
+          break
+        }
+      }
+      break
     default:
     // step has to be at least one in this case, otherwise the command does not contain a key
       if (command.step > 0) {


### PR DESCRIPTION
Example command: XREAD COUNT 2 STREAMS mystream writers 0-0 0-0

In this case, it should calculate slot on mystream and writers while it calculates on 'COUNT'. This is a bug in case of cluster mode.

Solution: now xread is considered a special case where we find all the streams name that are after keyword: STREAMS till ID starts.